### PR TITLE
Use correct timestamps for notes in submodule

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,4 @@ source "https://rubygems.org"
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 gem "jekyll", "~> 4.0"
-gem "jekyll-last-modified-at"
+gem "jekyll-last-modified-at", git: "https://github.com/maximevaillancourt/jekyll-last-modified-at", branch: "add-support-for-files-in-git-submodules"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: https://github.com/maximevaillancourt/jekyll-last-modified-at
+  revision: e0c918691db625401ef5850a030da59d0124d356
+  branch: add-support-for-files-in-git-submodules
+  specs:
+    jekyll-last-modified-at (1.3.0)
+      jekyll (>= 3.7, < 5.0)
+      posix-spawn (~> 0.3.9)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -29,9 +38,6 @@ GEM
       rouge (~> 3.0)
       safe_yaml (~> 1.0)
       terminal-table (~> 1.8)
-    jekyll-last-modified-at (1.2.1)
-      jekyll (>= 3.7, < 5.0)
-      posix-spawn (~> 0.3.9)
     jekyll-sass-converter (2.1.0)
       sassc (> 2.0.1, < 3.0)
     jekyll-watch (2.2.1)
@@ -47,7 +53,7 @@ GEM
     mercenary (0.3.6)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    posix-spawn (0.3.13)
+    posix-spawn (0.3.15)
     public_suffix (4.0.4)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.1)
@@ -66,7 +72,7 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll (~> 4.0)
-  jekyll-last-modified-at
+  jekyll-last-modified-at!
 
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
## What does this pull request achieve?

This pull request fixes the timestamps for the notes in the `_notes` Git submodule. This is a local fix for https://github.com/maximevaillancourt/digital-garden-jekyll-template/issues/12.

## How are we doing this?

This pull request updates the `jekyll-last-modified-at` gem to a [custom branch](https://github.com/gjtorikian/jekyll-last-modified-at/pull/82) that supports files in submodules. 

## Why are we doing this?

Notes in this repository are within a Git submodule (`_notes`), and this repository uses the `jekyll-last-modified-at` gem to show the "Last updated on" date. However, the `jekyll-last-modified-at` gem (as it stands now) doesn't know how to properly read commit timestamps for files within submodules.

----

## Example

Here's an example file from the within the `_notes` submodule:

![image](https://user-images.githubusercontent.com/8457808/96061228-386ae900-0e82-11eb-9479-4bc3b6b935d6.png)

Notice that the commit date of the file is October 11.

With this pull request, we properly get the October 11 date on the generated page:

![image](https://user-images.githubusercontent.com/8457808/96061109-df9b5080-0e81-11eb-8d12-e04a8abaebfb.png)

Without this pull request (`master` branch), the date corresponds to the moment when the submodule was updated in this repository ([view October 14 commit](https://github.com/digitalgardeners/digital-garden-jekyll-template/commit/ca1cacb8b0030330fe19cfbd33ef37f8ad6d49b4)):

![image](https://user-images.githubusercontent.com/8457808/96061152-fcd01f00-0e81-11eb-8253-635176c6f4c9.png)

---

I'll update [maximevaillancourt/digital-garden-jekyll-template](https://github.com/maximevaillancourt/digital-garden-jekyll-template) once https://github.com/gjtorikian/jekyll-last-modified-at/pull/82 merges, after which we'll be able to update this fork from [maximevaillancourt/digital-garden-jekyll-template](https://github.com/maximevaillancourt/digital-garden-jekyll-template).