### PR TITLE
Style invalid double-bracket links

### DIFF
--- a/_includes/link-previews.html
+++ b/_includes/link-previews.html
@@ -2,6 +2,7 @@
 <style>
   content a.internal-link {
     border-color: #8b88e6;
+    background-color: #efefff;
   }
 
   #tooltip-wrapper {

--- a/_plugins/bidirectional_links_generator.rb
+++ b/_plugins/bidirectional_links_generator.rb
@@ -18,6 +18,19 @@ class BidirectionalLinksGenerator < Jekyll::Generator
           "<a class='internal-link' href='#{note_potentially_linked_to.url}'>#{note_potentially_linked_to.data['title']}</a>"
         )
       end
+
+      # At this point, all remaining double-bracket-wrapped words are
+      # pointing to non-existing pages, so let's turn them into disabled
+      # links by greying them out and changing the cursor
+      current_note.content = current_note.content.gsub(
+        /\[\[?(.*)\]\]/i, # match on the remaining double-bracket links
+        <<~HTML.chomp     # replace with this HTML (\\1 is what was inside the brackets)
+          <span title='There is no note that matches this title.' class='invalid-link'>
+            <span class='invalid-link-brackets'>[[</span>
+            \\1
+            <span class='invalid-link-brackets'>]]</span></span>
+        HTML
+      )
     end
 
     # Identify note backlinks and add them to each note

--- a/_sass/_style.scss
+++ b/_sass/_style.scss
@@ -76,6 +76,8 @@ h6 {
 }
 
 a {
+  transition: background 300ms;
+  padding: 0 0.1em;
   text-decoration: none;
   border-bottom: 1px solid $color-border;
   color: $color-primary;
@@ -127,4 +129,16 @@ code {
   background: #f5f5f5;
   padding: 0.1em 0.2em;
   border-radius: 4px;
+}
+
+.invalid-link {
+  color: #444444;
+  cursor: help;
+  background: #fafafa;
+  padding: 0 0.1em;
+}
+
+.invalid-link-brackets {
+  color: #ccc;
+  cursor: help;
 }


### PR DESCRIPTION
This pull request syncs this repo with the [upstream](https://github.com/maximevaillancourt/digital-garden-jekyll-template) to get the latest changes. This updates invalid double-bracket links to be greyed out, like this:

**Screenshot**

![image](https://user-images.githubusercontent.com/8457808/96117810-2f0d6b00-0eda-11eb-96e8-6ed8a19f0f9b.png)

cc @binyamin