### PR TITLE
Add information about this repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,11 @@
-[![Netlify Status](https://api.netlify.com/api/v1/badges/8cfa8785-8df8-4aad-ad35-8f1c790b8baf/deploy-status)](https://app.netlify.com/sites/digital-garden-jekyll-template/deploys)
+# The Digital Gardeners' Digital Garden
 
-# Digital garden Jekyll template
+This is a public site of the [Digital Gardeners Telegram group](https://nesslabs.com/digital-gardeners)’s shared notes.
 
-Use this template repository to get started with your own digital garden.
+We want to keep a long-lived record of our community’s ideas and links (as opposed to them disappearing into timeline history), and keep an up-to-date map of tools and ideas.
 
-**I wrote a tutorial explaining how to set it up: [Setting up your own digital garden with Jekyll](https://maximevaillancourt.com/blog/setting-up-your-own-digital-garden-with-jekyll)**
+The notes themselves are in the [digitalgardeners/notes](https://github.com/digitalgardeners/notes) repository, and are included in this repository through the use of a Git submodule.
 
-Preview the template here: https://digital-garden-jekyll-template.netlify.app/
+These notes are not comprehensive, and are intended to be an introduction and a starting point - for more discussion and detail, on each note we keep a ‘Twin Pages’ section that links out to other digital gardens with more thoughts from individual gardeners.
 
-- Based on Jekyll, a static website generator
-- Supports Roam-style double bracket link syntax to other notes
-- Creates backlinks to other notes automatically
-- Features link previews on hover
-- Includes graph visualization of the notes and their links
-- Features a simple and responsive design
-- Supports Markdown or HTML notes
-
-<img width="1522" alt="Screen Shot 2020-05-19 at 23 05 46" src="https://user-images.githubusercontent.com/8457808/82400515-7d026d80-9a25-11ea-83f1-3b9cb8347e07.png">
-
-## License
-
-Source code is available under the [MIT license](LICENSE.md).
+This repository is based on [Maxime Vaillancourt’s Jekyll template for digital gardens](https://github.com/maximevaillancourt/digital-garden-jekyll-template).


### PR DESCRIPTION
This pull request removes the template README and replaces it with actual information about this repository.

@ngm:
- We should consider renaming this repository to something more relevant, like `digital-garden`, or just `garden`. Maybe `metagarden` could be a fun way to represent that this is a garden about gardens? Either way, renaming the repo will preserve any existing links to its current name (`digitalgardeners/digital-garden-jekyll-template`), so it's a safe operation.
- We could also update the URL of the repo to point to https://digitalgardeners.netlify.app/ instead of my template. While we're here, do we want to buy a domain for this? `gardeners.garden` is $130/year (then renews at $35/year), which is not exactly cheap, but would be a fun novelty domain name to have for this.